### PR TITLE
Add Vocos as a dependency to F5TTS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
                 .product(name: "MLXFFT", package: "mlx-swift"),
                 .product(name: "MLXLinalg", package: "mlx-swift"),
                 .product(name: "MLXRandom", package: "mlx-swift"),
-                .product(name: "Transformers", package: "swift-transformers")
+                .product(name: "Transformers", package: "swift-transformers"),
+                .product(name: "Vocos", package: "vocos-swift"),
             ],
             path: "Sources/F5TTS",
             resources: [


### PR DESCRIPTION
Thank you for your work! I was adding it to my app and got the error `import Vocos`. I realized it has to be added as a dependency to the target `F5TTS`, too, as it is using it. Cheers!